### PR TITLE
Update PaperInkConverter.cpp

### DIFF
--- a/PaperInkConverter/PaperInkConverter/PaperInkConverter.cpp
+++ b/PaperInkConverter/PaperInkConverter/PaperInkConverter.cpp
@@ -257,7 +257,7 @@ short*  PaperInkConverter::GetPenPositionY() {
 		return(temp);
 	};
 short*  PaperInkConverter::GetPenPressure() {
-		short* temp = pPenPositionStart_X + *(SensitivityStrokeIndexList+SubStrokeIndex);
+		short* temp = pPenPressureStart + *(SensitivityStrokeIndexList+SubStrokeIndex);
 		return(temp);
 	};
 


### PR DESCRIPTION
Bug fix. Pen Pressure was incorrectly pointing to Pen X.
